### PR TITLE
fix: Fix panic in evaluating `shareProcessNamespace`

### DIFF
--- a/pkg/sidecarterminator/terminator.go
+++ b/pkg/sidecarterminator/terminator.go
@@ -136,7 +136,7 @@ func (st *SidecarTerminator) terminate(pod *v1.Pod) error {
 			// TODO: Add ability to kill the proper process
 			// May require looking into the OCI image to extract the entrypoint if not
 			// available via the containers' command.
-			if *pod.Spec.ShareProcessNamespace {
+			if pod.Spec.ShareProcessNamespace != nil && *pod.Spec.ShareProcessNamespace {
 				klog.Error("Containers are sharing process namespace: ending process 1 will not end sidecars.")
 				return fmt.Errorf("unable to end sidecar %s in pod %s using shareProcessNamespace", sidecar.Name, podName(pod))
 			}


### PR DESCRIPTION
This should resolve the following panic:

```
I0208 20:35:31.451630       1 terminator.go:130] Found running sidecar containers in logging/rotate-logging-indexes-rotate-elasticsearch-index-manual-ksjgxf
E0208 20:35:31.451833       1 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 68 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x15967a0?, 0x24c9f50})
        /go/pkg/mod/k8s.io/apimachinery@v0.23.15/pkg/util/runtime/runtime.go:74 +0x99
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc0000e56a0?})
        /go/pkg/mod/k8s.io/apimachinery@v0.23.15/pkg/util/runtime/runtime.go:48 +0x75
panic({0x15967a0, 0x24c9f50})
        /usr/local/go/src/runtime/panic.go:884 +0x212
github.com/zachomedia/kubernetes-sidecar-terminator/pkg/sidecarterminator.(*SidecarTerminator).terminate(0xc0003e1220, 0xc0007a6650)
        /go/src/github.com/zachomedia/kubernetes-sidecar-terminator/pkg/sidecarterminator/terminator.go:139 +0x263
github.com/zachomedia/kubernetes-sidecar-terminator/pkg/sidecarterminator.(*sidecarTerminatorEventHandler).handle(0xc0000b8020, 0xc0007a6650)
        /go/src/github.com/zachomedia/kubernetes-sidecar-terminator/pkg/sidecarterminator/eventhandler.go:32 +0xe6
github.com/zachomedia/kubernetes-sidecar-terminator/pkg/sidecarterminator.(*sidecarTerminatorEventHandler).OnAdd(0x0?, {0x1767280?, 0xc0007a6650?})
        /go/src/github.com/zachomedia/kubernetes-sidecar-terminator/pkg/sidecarterminator/eventhandler.go:16 +0x45
k8s.io/client-go/tools/cache.(*processorListener).run.func1()
        /go/pkg/mod/k8s.io/client-go@v0.23.15/tools/cache/shared_informer.go:787 +0x134
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x1000251fe00?)
        /go/pkg/mod/k8s.io/apimachinery@v0.23.15/pkg/util/wait/wait.go:155 +0x3e
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc00006f738?, {0x19b7c60, 0xc00010e8d0}, 0x1, 0xc000596120)
        /go/pkg/mod/k8s.io/apimachinery@v0.23.15/pkg/util/wait/wait.go:156 +0xb6
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x0?, 0x3b9aca00, 0x0, 0x0?, 0xc00006f788?)
        /go/pkg/mod/k8s.io/apimachinery@v0.23.15/pkg/util/wait/wait.go:133 +0x89
k8s.io/apimachinery/pkg/util/wait.Until(...)
        /go/pkg/mod/k8s.io/apimachinery@v0.23.15/pkg/util/wait/wait.go:90
k8s.io/client-go/tools/cache.(*processorListener).run(0xc00017e380?)
        /go/pkg/mod/k8s.io/client-go@v0.23.15/tools/cache/shared_informer.go:781 +0x6b
k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
        /go/pkg/mod/k8s.io/apimachinery@v0.23.15/pkg/util/wait/wait.go:73 +0x5a
created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start
        /go/pkg/mod/k8s.io/apimachinery@v0.23.15/pkg/util/wait/wait.go:71 +0x85
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x13e1163]

goroutine 68 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc0000e56a0?})
        /go/pkg/mod/k8s.io/apimachinery@v0.23.15/pkg/util/runtime/runtime.go:55 +0xd7
panic({0x15967a0, 0x24c9f50})
        /usr/local/go/src/runtime/panic.go:884 +0x212
github.com/zachomedia/kubernetes-sidecar-terminator/pkg/sidecarterminator.(*SidecarTerminator).terminate(0xc0003e1220, 0xc0007a6650)
        /go/src/github.com/zachomedia/kubernetes-sidecar-terminator/pkg/sidecarterminator/terminator.go:139 +0x263
github.com/zachomedia/kubernetes-sidecar-terminator/pkg/sidecarterminator.(*sidecarTerminatorEventHandler).handle(0xc0000b8020, 0xc0007a6650)
        /go/src/github.com/zachomedia/kubernetes-sidecar-terminator/pkg/sidecarterminator/eventhandler.go:32 +0xe6
github.com/zachomedia/kubernetes-sidecar-terminator/pkg/sidecarterminator.(*sidecarTerminatorEventHandler).OnAdd(0x0?, {0x1767280?, 0xc0007a6650?})
        /go/src/github.com/zachomedia/kubernetes-sidecar-terminator/pkg/sidecarterminator/eventhandler.go:16 +0x45
k8s.io/client-go/tools/cache.(*processorListener).run.func1()
        /go/pkg/mod/k8s.io/client-go@v0.23.15/tools/cache/shared_informer.go:787 +0x134
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x1000251fe00?)
        /go/pkg/mod/k8s.io/apimachinery@v0.23.15/pkg/util/wait/wait.go:155 +0x3e
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc00006f738?, {0x19b7c60, 0xc00010e8d0}, 0x1, 0xc000596120)
        /go/pkg/mod/k8s.io/apimachinery@v0.23.15/pkg/util/wait/wait.go:156 +0xb6
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x0?, 0x3b9aca00, 0x0, 0x0?, 0xc00006f788?)
        /go/pkg/mod/k8s.io/apimachinery@v0.23.15/pkg/util/wait/wait.go:133 +0x89
k8s.io/apimachinery/pkg/util/wait.Until(...)
        /go/pkg/mod/k8s.io/apimachinery@v0.23.15/pkg/util/wait/wait.go:90
k8s.io/client-go/tools/cache.(*processorListener).run(0xc00017e380?)
        /go/pkg/mod/k8s.io/client-go@v0.23.15/tools/cache/shared_informer.go:781 +0x6b
k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
        /go/pkg/mod/k8s.io/apimachinery@v0.23.15/pkg/util/wait/wait.go:73 +0x5a
created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start
        /go/pkg/mod/k8s.io/apimachinery@v0.23.15/pkg/util/wait/wait.go:71 +0x85
```